### PR TITLE
Adding delivery model stub

### DIFF
--- a/modules/apim-endpoints/approvals/delivery-models.json
+++ b/modules/apim-endpoints/approvals/delivery-models.json
@@ -1,0 +1,3 @@
+{
+  "DeliveryModels": [0, 1, 2]
+}

--- a/modules/apim-endpoints/approvals/fjaa-agency.json
+++ b/modules/apim-endpoints/approvals/fjaa-agency.json
@@ -1,0 +1,4 @@
+{
+  "legalEntityId": 2818,
+  "isGrantFunded": false
+}

--- a/modules/apim-endpoints/approvals/module.js
+++ b/modules/apim-endpoints/approvals/module.js
@@ -14,4 +14,30 @@ module.exports = function(app) {
 
     });
 
+
+    app.get('/apim-endpoints/approvals/Providers/:providerId/courses/:courseCode',(req, res) => {
+
+        let providerId = req.params.providerId;
+        let courseCode = req.params.courseCode;
+
+        console.log(string.format("providerId {0}", providerId));
+        console.log(string.format("courseCode {0}", courseCode));
+
+        files.sendFile(res, '/modules/apim-endpoints/approvals/delivery-models.json');
+
+    });
+
+
+    app.get('/apim-endpoints/approvals/rofjaa/agency/:legalEntityId',(req, res) => {
+
+        let legalEntityId = req.params.legalEntityId;
+
+        console.log(string.format("legalEntityId {0}", legalEntityId));
+
+        files.sendFile(res, '/modules/apim-endpoints/approvals/fjaa-agency.json');
+
+    });
+
+
+
 };


### PR DESCRIPTION
Hi Chris, added a couple new stubs in order for the ECV2 application to work with the FJAA work. Two endpoints, one that returns agency/:legalEntityId - > fjaa-agency.json, one that returns the delivery models -> delivery-models.json.

